### PR TITLE
feat(vm): create database schema for proxmox nodes, templates, and se…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,4 @@ yarn-error.log
 /.nova
 /.vscode
 /.zed
+/docs

--- a/app/Enums/ProxmoxNodeStatus.php
+++ b/app/Enums/ProxmoxNodeStatus.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace App\Enums;
+
+enum ProxmoxNodeStatus: string
+{
+    case ONLINE = 'online';
+    case OFFLINE = 'offline';
+    case MAINTENANCE = 'maintenance';
+
+    public static function values(): array
+    {
+        return array_map(fn(self $c) => $c->value, self::cases());
+    }
+}

--- a/app/Enums/VMSessionStatus.php
+++ b/app/Enums/VMSessionStatus.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Enums;
+
+enum VMSessionStatus: string
+{
+    case PENDING = 'pending';
+    case PROVISIONING = 'provisioning';
+    case ACTIVE = 'active';
+    case EXPIRING = 'expiring';
+    case EXPIRED = 'expired';
+    case FAILED = 'failed';
+    case TERMINATED = 'terminated';
+
+    public static function values(): array
+    {
+        return array_map(fn(self $c) => $c->value, self::cases());
+    }
+}

--- a/app/Enums/VMSessionType.php
+++ b/app/Enums/VMSessionType.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace App\Enums;
+
+enum VMSessionType: string
+{
+    case EPHEMERAL = 'ephemeral';
+    case PERSISTENT = 'persistent';
+
+    public static function values(): array
+    {
+        return array_map(fn(self $c) => $c->value, self::cases());
+    }
+}

--- a/app/Enums/VMTemplateOSType.php
+++ b/app/Enums/VMTemplateOSType.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace App\Enums;
+
+enum VMTemplateOSType: string
+{
+    case WINDOWS = 'windows';
+    case LINUX = 'linux';
+
+    public static function values(): array
+    {
+        return array_map(fn(self $c) => $c->value, self::cases());
+    }
+}

--- a/app/Enums/VMTemplateProtocol.php
+++ b/app/Enums/VMTemplateProtocol.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace App\Enums;
+
+enum VMTemplateProtocol: string
+{
+    case RDP = 'rdp';
+    case VNC = 'vnc';
+    case SSH = 'ssh';
+
+    public static function values(): array
+    {
+        return array_map(fn(self $c) => $c->value, self::cases());
+    }
+}

--- a/app/Models/ProxmoxNode.php
+++ b/app/Models/ProxmoxNode.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace App\Models;
+
+use App\Enums\ProxmoxNodeStatus;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+
+/**
+ * App Proxmox node model.
+ *
+ * @property int $id
+ * @property string $name
+ * @property string $hostname
+ * @property string $api_url
+ * @property ProxmoxNodeStatus $status
+ * @property int $max_vms
+ */
+class ProxmoxNode extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'name',
+        'hostname',
+        'api_url',
+        'status',
+        'max_vms',
+    ];
+
+    protected $casts = [
+        'status' => ProxmoxNodeStatus::class,
+        'max_vms' => 'integer',
+    ];
+
+    public function vmSessions(): HasMany
+    {
+        return $this->hasMany(VMSession::class, 'node_id');
+    }
+}

--- a/app/Models/VMSession.php
+++ b/app/Models/VMSession.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace App\Models;
+
+use App\Enums\VMSessionStatus;
+use App\Enums\VMSessionType;
+use Illuminate\Database\Eloquent\Concerns\HasUlids;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+/**
+ * App VM session model.
+ *
+ * @property string $id
+ * @property string $user_id
+ * @property int $template_id
+ * @property int $node_id
+ * @property int|null $vm_id
+ * @property VMSessionStatus $status
+ * @property VMSessionType $session_type
+ * @property string|null $ip_address
+ * @property int|null $guacamole_connection_id
+ * @property \DateTime $expires_at
+ */
+class VMSession extends Model
+{
+    use HasFactory, HasUlids;
+
+    protected $fillable = [
+        'user_id',
+        'template_id',
+        'node_id',
+        'vm_id',
+        'status',
+        'session_type',
+        'ip_address',
+        'guacamole_connection_id',
+        'expires_at',
+    ];
+
+    protected $casts = [
+        'status' => VMSessionStatus::class,
+        'session_type' => VMSessionType::class,
+        'expires_at' => 'datetime',
+        'template_id' => 'integer',
+        'node_id' => 'integer',
+        'vm_id' => 'integer',
+        'guacamole_connection_id' => 'integer',
+    ];
+
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
+    }
+
+    public function template(): BelongsTo
+    {
+        return $this->belongsTo(VMTemplate::class);
+    }
+
+    public function node(): BelongsTo
+    {
+        return $this->belongsTo(ProxmoxNode::class);
+    }
+}

--- a/app/Models/VMTemplate.php
+++ b/app/Models/VMTemplate.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace App\Models;
+
+use App\Enums\VMTemplateOSType;
+use App\Enums\VMTemplateProtocol;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+
+/**
+ * App VM template model.
+ *
+ * @property int $id
+ * @property string $name
+ * @property VMTemplateOSType $os_type
+ * @property VMTemplateProtocol $protocol
+ * @property int $template_vmid
+ * @property int $cpu_cores
+ * @property int $ram_mb
+ * @property int $disk_gb
+ * @property array $tags
+ * @property bool $is_active
+ */
+class VMTemplate extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'name',
+        'os_type',
+        'protocol',
+        'template_vmid',
+        'cpu_cores',
+        'ram_mb',
+        'disk_gb',
+        'tags',
+        'is_active',
+    ];
+
+    protected $casts = [
+        'os_type' => VMTemplateOSType::class,
+        'protocol' => VMTemplateProtocol::class,
+        'tags' => 'array',
+        'is_active' => 'boolean',
+        'cpu_cores' => 'integer',
+        'ram_mb' => 'integer',
+        'disk_gb' => 'integer',
+        'template_vmid' => 'integer',
+    ];
+
+    public function vmSessions(): HasMany
+    {
+        return $this->hasMany(VMSession::class, 'template_id');
+    }
+}

--- a/database/factories/ProxmoxNodeFactory.php
+++ b/database/factories/ProxmoxNodeFactory.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Enums\ProxmoxNodeStatus;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\ProxmoxNode>
+ */
+class ProxmoxNodeFactory extends Factory
+{
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        $nodeNumber = fake()->numberBetween(1, 7);
+
+        return [
+            'name' => "pve-node-{$nodeNumber}",
+            'hostname' => "pve-node-{$nodeNumber}.lab.local",
+            'api_url' => "https://192.168.1.1{$nodeNumber}0:8006",
+            'status' => ProxmoxNodeStatus::ONLINE->value,
+            'max_vms' => 50,
+        ];
+    }
+
+    public function offline(): static
+    {
+        return $this->state(fn (array $attributes) => [
+            'status' => ProxmoxNodeStatus::OFFLINE->value,
+        ]);
+    }
+
+    public function maintenance(): static
+    {
+        return $this->state(fn (array $attributes) => [
+            'status' => ProxmoxNodeStatus::MAINTENANCE->value,
+        ]);
+    }
+}
+

--- a/database/factories/VMSessionFactory.php
+++ b/database/factories/VMSessionFactory.php
@@ -1,0 +1,94 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Enums\VMSessionStatus;
+use App\Enums\VMSessionType;
+use App\Models\ProxmoxNode;
+use App\Models\User;
+use App\Models\VMTemplate;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\VMSession>
+ */
+class VMSessionFactory extends Factory
+{
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            'user_id' => User::factory(),
+            'template_id' => VMTemplate::factory(),
+            'node_id' => ProxmoxNode::factory(),
+            'vm_id' => null,
+            'status' => VMSessionStatus::PENDING->value,
+            'session_type' => VMSessionType::EPHEMERAL->value,
+            'ip_address' => null,
+            'guacamole_connection_id' => null,
+            'expires_at' => now()->addHours(4),
+        ];
+    }
+
+    public function active(): static
+    {
+        return $this->state(fn (array $attributes) => [
+            'status' => VMSessionStatus::ACTIVE->value,
+            'vm_id' => fake()->unique()->numberBetween(200, 999),
+            'ip_address' => fake()->ipv4(),
+            'guacamole_connection_id' => fake()->numberBetween(1, 1000),
+        ]);
+    }
+
+    public function pending(): static
+    {
+        return $this->state(fn (array $attributes) => [
+            'status' => VMSessionStatus::PENDING->value,
+            'vm_id' => null,
+            'ip_address' => null,
+            'guacamole_connection_id' => null,
+        ]);
+    }
+
+    public function provisioning(): static
+    {
+        return $this->state(fn (array $attributes) => [
+            'status' => VMSessionStatus::PROVISIONING->value,
+            'vm_id' => fake()->unique()->numberBetween(200, 999),
+            'ip_address' => null,
+            'guacamole_connection_id' => null,
+        ]);
+    }
+
+    public function failed(): static
+    {
+        return $this->state(fn (array $attributes) => [
+            'status' => VMSessionStatus::FAILED->value,
+            'vm_id' => null,
+            'ip_address' => null,
+            'guacamole_connection_id' => null,
+        ]);
+    }
+
+    public function expired(): static
+    {
+        return $this->state(fn (array $attributes) => [
+            'status' => VMSessionStatus::EXPIRED->value,
+            'vm_id' => null,
+            'expires_at' => now()->subHours(2),
+        ]);
+    }
+
+    public function persistent(): static
+    {
+        return $this->state(fn (array $attributes) => [
+            'session_type' => VMSessionType::PERSISTENT->value,
+            'expires_at' => now()->addDays(30),
+        ]);
+    }
+}
+

--- a/database/factories/VMTemplateFactory.php
+++ b/database/factories/VMTemplateFactory.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Enums\VMTemplateOSType;
+use App\Enums\VMTemplateProtocol;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\VMTemplate>
+ */
+class VMTemplateFactory extends Factory
+{
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            'name' => fake()->word() . '-template',
+            'os_type' => fake()->randomElement([VMTemplateOSType::WINDOWS, VMTemplateOSType::LINUX])->value,
+            'protocol' => VMTemplateProtocol::RDP->value,
+            'template_vmid' => fake()->unique()->numberBetween(100, 199),
+            'cpu_cores' => fake()->randomElement([2, 4, 8]),
+            'ram_mb' => fake()->randomElement([2048, 4096, 8192]),
+            'disk_gb' => fake()->randomElement([40, 80, 120]),
+            'tags' => ['production', 'testing'],
+            'is_active' => true,
+        ];
+    }
+
+    public function windows11(): static
+    {
+        return $this->state(fn (array $attributes) => [
+            'name' => 'Windows 11 Enterprise',
+            'os_type' => VMTemplateOSType::WINDOWS->value,
+            'protocol' => VMTemplateProtocol::RDP->value,
+            'template_vmid' => 110,
+            'cpu_cores' => 4,
+            'ram_mb' => 4096,
+            'disk_gb' => 80,
+            'tags' => ['windows', 'production'],
+        ]);
+    }
+
+    public function ubuntu2204(): static
+    {
+        return $this->state(fn (array $attributes) => [
+            'name' => 'Ubuntu 22.04 LTS',
+            'os_type' => VMTemplateOSType::LINUX->value,
+            'protocol' => VMTemplateProtocol::SSH->value,
+            'template_vmid' => 120,
+            'cpu_cores' => 2,
+            'ram_mb' => 2048,
+            'disk_gb' => 40,
+            'tags' => ['linux', 'ubuntu', 'production'],
+        ]);
+    }
+
+    public function kaliLinux(): static
+    {
+        return $this->state(fn (array $attributes) => [
+            'name' => 'Kali Linux Rolling',
+            'os_type' => VMTemplateOSType::LINUX->value,
+            'protocol' => VMTemplateProtocol::VNC->value,
+            'template_vmid' => 130,
+            'cpu_cores' => 4,
+            'ram_mb' => 4096,
+            'disk_gb' => 80,
+            'tags' => ['linux', 'kali', 'security-testing'],
+        ]);
+    }
+
+    public function inactive(): static
+    {
+        return $this->state(fn (array $attributes) => [
+            'is_active' => false,
+        ]);
+    }
+}
+

--- a/database/migrations/2026_02_18_180508_create_proxmox_nodes_table.php
+++ b/database/migrations/2026_02_18_180508_create_proxmox_nodes_table.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('proxmox_nodes', function (Blueprint $table) {
+            $table->id();
+            $table->string('name', 100)->unique();
+            $table->string('hostname', 255)->unique();
+            $table->string('api_url', 255);
+            $table->enum('status', ['online', 'offline', 'maintenance'])->default('offline');
+            $table->unsignedInteger('max_vms')->default(50);
+            $table->timestamps();
+
+            $table->index('status');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('proxmox_nodes');
+    }
+};

--- a/database/migrations/2026_02_18_180524_create_vm_templates_table.php
+++ b/database/migrations/2026_02_18_180524_create_vm_templates_table.php
@@ -1,0 +1,39 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('vm_templates', function (Blueprint $table) {
+            $table->id();
+            $table->string('name', 255)->unique();
+            $table->enum('os_type', ['windows', 'linux'])->default('linux');
+            $table->enum('protocol', ['rdp', 'vnc', 'ssh'])->default('vnc');
+            $table->unsignedInteger('template_vmid')->unique();
+            $table->unsignedSmallInteger('cpu_cores')->default(2);
+            $table->unsignedInteger('ram_mb')->default(2048);
+            $table->unsignedSmallInteger('disk_gb')->default(40);
+            $table->json('tags')->nullable();
+            $table->boolean('is_active')->default(true);
+            $table->timestamps();
+
+            $table->index('os_type');
+            $table->index('is_active');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('vm_templates');
+    }
+};

--- a/database/migrations/2026_02_18_180538_create_vm_sessions_table.php
+++ b/database/migrations/2026_02_18_180538_create_vm_sessions_table.php
@@ -1,0 +1,42 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('vm_sessions', function (Blueprint $table) {
+            $table->ulid('id')->primary();
+            $table->foreignUlid('user_id')->constrained('users')->cascadeOnDelete();
+            $table->foreignId('template_id')->constrained('vm_templates')->cascadeOnDelete();
+            $table->foreignId('node_id')->constrained('proxmox_nodes')->restrictOnDelete();
+            $table->unsignedInteger('vm_id')->unique()->nullable();
+            $table->enum('status', ['pending', 'provisioning', 'active', 'expiring', 'expired', 'failed', 'terminated'])->default('pending');
+            $table->enum('session_type', ['ephemeral', 'persistent'])->default('ephemeral');
+            $table->ipAddress()->nullable();
+            $table->unsignedBigInteger('guacamole_connection_id')->nullable();
+            $table->timestamp('expires_at')->nullable();
+            $table->timestamps();
+
+            $table->index('user_id');
+            $table->index('status');
+            $table->index('expires_at');
+            $table->index('node_id');
+            $table->index('template_id');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('vm_sessions');
+    }
+};


### PR DESCRIPTION
…ssions

Create three core tables for Proxmox integration:
- proxmox_nodes: Track Proxmox cluster nodes with status and capacity
- vm_templates: Store OS templates with protocol and resource configs
- vm_sessions: User sessions with ULID PK and proper foreign keys

Add corresponding Eloquent models with relationships and type casting. Add string-backed enums for all status fields.
Add factories with realistic data including helper states.

Indexes on frequently queried columns: user_id, status, expires_at. Foreign keys configured with cascade deletes where appropriate.

Closes #6